### PR TITLE
added postgreSQL connection parameters and database scripts

### DIFF
--- a/de.nk.camel/pom.xml
+++ b/de.nk.camel/pom.xml
@@ -138,7 +138,13 @@
 			<artifactId>mysql-connector-java</artifactId>
 			<version>5.1.25</version>
 		</dependency>
-		
+		<!-- PostgreSQL -->
+		<dependency>
+			<groupId>postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>9.1-901.jdbc3</version>
+		</dependency>
+        
 		<!-- Util -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/de.nk.camel/src/main/resources/META-INF/persistence.xml
+++ b/de.nk.camel/src/main/resources/META-INF/persistence.xml
@@ -12,6 +12,11 @@
             <property name="hibernate.dialect" value="org.hibernate.dialect.MySQLInnoDBDialect" />
             <property name="hibernate.connection.driver_class" value="com.mysql.jdbc.Driver"/>
             <property name="hibernate.connection.url" value="jdbc:mysql://localhost:3306/camel?user=root" />
+<!-- 
+            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />
+            <property name="hibernate.connection.driver_class" value="org.postgresql.Driver"/>
+            <property name="hibernate.connection.url" value="jdbc:postgresql://localhost:5432/camel" />
+ -->
             <property name="hibernate.show_sql" value="true" />
             <property name="hibernate.format_sql" value="false" />
             <property name="hibernate.use_sql_comments" value="false" />

--- a/de.nk.camel/src/test/resources/create_postgres.sh
+++ b/de.nk.camel/src/test/resources/create_postgres.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DBNAME=camel
+HOST=localhost
+
+dropdb -e --host $HOST $DBNAME || true
+createdb -e --host $HOST $DBNAME
+psql -e --host $HOST -d $DBNAME -f schema_postgres.sql 

--- a/de.nk.camel/src/test/resources/schema_postgres.sql
+++ b/de.nk.camel/src/test/resources/schema_postgres.sql
@@ -1,0 +1,5 @@
+CREATE TABLE camel_demo (
+	"id" bigint primary key not null,
+	"message" VARCHAR(255),
+	"datetime" timestamp with time zone
+);


### PR DESCRIPTION
Contains postgreSQL database script that creates the camel database and the camel_demo table. Don't know if it is useful to have support for multiple databases in a tutorial, but I thought I'll leave that up to you.
